### PR TITLE
fix(gcovr): add explicit 8.0 schema support

### DIFF
--- a/cmake/GcovrSchema.cmake
+++ b/cmake/GcovrSchema.cmake
@@ -27,7 +27,7 @@ include_guard(GLOBAL)
 #   OUTPUT_VAR - Variable name to store the list of supported versions
 #
 function(GcovrSchema_GetSupportedVersions OUTPUT_VAR)
-    set(SUPPORTED_VERSIONS "7.0")
+    set(SUPPORTED_VERSIONS "7.0;8.0")
     set(${OUTPUT_VAR} "${SUPPORTED_VERSIONS}" PARENT_SCOPE)
 endfunction()
 
@@ -57,7 +57,7 @@ function(GcovrSchema_DetectVersion GCOVR_EXE OUTPUT_VAR)
         )
 
         if(gcovr_version_result EQUAL 0 AND gcovr_version_output)
-            # Extract version from output (format: "gcovr 7.0" or "gcovr 7.2.1")
+            # Extract version from output (format: "gcovr 7.0", "gcovr 7.2.1", "gcovr 8.6")
             if(gcovr_version_output MATCHES "gcovr ([0-9]+)\\.([0-9]+)")
                 set(DETECTED_VERSION "${CMAKE_MATCH_1}.${CMAKE_MATCH_2}")
                 message(
@@ -93,11 +93,11 @@ function(GcovrSchema_DetectVersion GCOVR_EXE OUTPUT_VAR)
             return()
         endif()
 
-        # Try to find a compatible major version schema
-        string(REGEX MATCH "^([0-9]+)" MAJOR_VERSION "${DETECTED_VERSION}")
+        # Try to find a compatible schema by major version.
+        string(REGEX MATCH "^([0-9]+)" DETECTED_MAJOR "${DETECTED_VERSION}")
         foreach(supported IN LISTS SUPPORTED_VERSIONS)
             string(REGEX MATCH "^([0-9]+)" supported_major "${supported}")
-            if(MAJOR_VERSION STREQUAL supported_major)
+            if(DETECTED_MAJOR STREQUAL supported_major)
                 set(${OUTPUT_VAR} "${supported}" PARENT_SCOPE)
                 message(
                     STATUS

--- a/cmake/schemas/gcovr-8.0.cmake
+++ b/cmake/schemas/gcovr-8.0.cmake
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: MIT
+# ==============================================================================
+# Gcovr 8.0 Schema and Configuration Generator
+# ==============================================================================
+#
+# gcovr 8.x keeps compatibility with the configuration keys emitted by our 7.0
+# schema for the options currently managed by cmake_toolbox. Reuse the 7.0
+# schema implementation while exposing an explicit 8.0 schema entry point.
+#
+# ==============================================================================
+
+include("${CMAKE_CURRENT_LIST_DIR}/gcovr-7.0.cmake")
+
+function(GcovrSchema_8_0_GenerateConfig CONFIG_FILE)
+    GcovrSchema_7_0_GenerateConfig("${CONFIG_FILE}")
+endfunction()

--- a/unit_tests/gcovrschema/test_detect_version.cmake
+++ b/unit_tests/gcovrschema/test_detect_version.cmake
@@ -85,8 +85,26 @@ function(test_detect_compatible_patch_version)
     message(STATUS "  ✓ Correctly mapped 7.2.1 to schema 7.0")
 endfunction()
 
+function(test_detect_compatible_mapped_major_version)
+    message(STATUS "Test 3: Detect compatible major version (8.6 -> 8.0)")
+
+    set(mock_gcovr "${TEST_ROOT}/gcovr_8_6")
+    create_mock_gcovr("${mock_gcovr}" "gcovr 8.6")
+
+    GcovrSchema_DetectVersion("${mock_gcovr}" detected_version)
+
+    if(NOT detected_version STREQUAL "8.0")
+        message(STATUS "  ✗ Expected '8.0' for 8.6, got '${detected_version}'")
+        math(EXPR ERROR_COUNT "${ERROR_COUNT} + 1")
+        set(ERROR_COUNT "${ERROR_COUNT}" PARENT_SCOPE)
+        return()
+    endif()
+
+    message(STATUS "  ✓ Correctly mapped 8.6 to schema 8.0")
+endfunction()
+
 function(test_detect_unsupported_version)
-    message(STATUS "Test 3: Unsupported version returns empty string (6.0)")
+    message(STATUS "Test 4: Unsupported version returns empty string (6.0)")
 
     set(mock_gcovr "${TEST_ROOT}/gcovr_6_0")
     create_mock_gcovr("${mock_gcovr}" "gcovr 6.0")
@@ -104,7 +122,7 @@ function(test_detect_unsupported_version)
 endfunction()
 
 function(test_detect_nonexistent_executable)
-    message(STATUS "Test 4: Non-existent executable returns empty string")
+    message(STATUS "Test 5: Non-existent executable returns empty string")
 
     set(fake_path "${TEST_ROOT}/nonexistent_gcovr_binary")
 
@@ -121,7 +139,7 @@ function(test_detect_nonexistent_executable)
 endfunction()
 
 function(test_detect_malformed_output)
-    message(STATUS "Test 5: Malformed version output returns empty string")
+    message(STATUS "Test 6: Malformed version output returns empty string")
 
     set(mock_gcovr "${TEST_ROOT}/gcovr_malformed")
     create_mock_gcovr("${mock_gcovr}" "some random output without version")
@@ -139,7 +157,7 @@ function(test_detect_malformed_output)
 endfunction()
 
 function(test_detect_empty_executable_path)
-    message(STATUS "Test 6: Empty executable path returns empty string")
+    message(STATUS "Test 7: Empty executable path returns empty string")
 
     GcovrSchema_DetectVersion("" detected_version)
 
@@ -154,7 +172,7 @@ function(test_detect_empty_executable_path)
 endfunction()
 
 function(test_output_variable_scope)
-    message(STATUS "Test 7: Output variable is set in caller scope")
+    message(STATUS "Test 8: Output variable is set in caller scope")
 
     set(mock_gcovr "${TEST_ROOT}/gcovr_scope_test")
     create_mock_gcovr("${mock_gcovr}" "gcovr 7.0")
@@ -179,6 +197,7 @@ function(run_all_tests)
 
     test_detect_supported_version_exact()
     test_detect_compatible_patch_version()
+    test_detect_compatible_mapped_major_version()
     test_detect_unsupported_version()
     test_detect_nonexistent_executable()
     test_detect_malformed_output()

--- a/unit_tests/gcovrschema/test_supported_versions.cmake
+++ b/unit_tests/gcovrschema/test_supported_versions.cmake
@@ -47,8 +47,28 @@ function(test_contains_expected_version)
     message(STATUS "  ✓ Version 7.0 found in supported versions")
 endfunction()
 
+function(test_contains_expected_version_8_0)
+    message(STATUS "Test 3: Supported versions contains '8.0'")
+
+    GcovrSchema_GetSupportedVersions(versions)
+
+    list(
+        FIND versions
+        "8.0"
+        version_index
+    )
+    if(version_index EQUAL -1)
+        message(STATUS "  ✗ Version 8.0 not found in: ${versions}")
+        math(EXPR ERROR_COUNT "${ERROR_COUNT} + 1")
+        set(ERROR_COUNT "${ERROR_COUNT}" PARENT_SCOPE)
+        return()
+    endif()
+
+    message(STATUS "  ✓ Version 8.0 found in supported versions")
+endfunction()
+
 function(test_version_format)
-    message(STATUS "Test 3: Versions follow MAJOR.MINOR format")
+    message(STATUS "Test 4: Versions follow MAJOR.MINOR format")
 
     GcovrSchema_GetSupportedVersions(versions)
 
@@ -65,7 +85,7 @@ function(test_version_format)
 endfunction()
 
 function(test_output_variable_set)
-    message(STATUS "Test 4: Output variable is set correctly")
+    message(STATUS "Test 5: Output variable is set correctly")
 
     # Ensure variable doesn't exist before call
     unset(my_output)
@@ -87,6 +107,7 @@ function(run_all_tests)
 
     test_returns_non_empty_list()
     test_contains_expected_version()
+    test_contains_expected_version_8_0()
     test_version_format()
     test_output_variable_set()
 


### PR DESCRIPTION
## Summary
- add explicit `gcovr` schema support for `8.0` and include it in supported versions
- map detected `gcovr 8.x` versions to schema `8.0` via major-version compatibility
- extend gcovr schema unit tests to validate `8.6 -> 8.0` detection and supported versions list

## Notes
- this unblocks CI on environments that install `gcovr 8.x` by default (e.g. macOS)
- follow-up tracking for broader version/fallback strategy: #26