### PR TITLE
feat(ceedling): optional CException integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,27 @@ jobs:
               sudo apt-get update
               sudo apt-get install -y clang clang-format gcovr llvm
 
+          # ── Linux + CException ───────────────────────────────────────────
+          - name: linux-cexception
+            os: ubuntu-latest
+            cmake_flags: >-
+              -DCMAKE_TOOLBOX_BUILD_EXAMPLES=ON
+              -DCMT_CEEDLING_USE_CEXCEPTION=ON
+            install_deps: |
+              sudo apt-get update
+              sudo apt-get install -y clang-format gcovr
+
+          - name: linux-clang-cexception
+            os: ubuntu-latest
+            cmake_flags: >-
+              -DCMAKE_TOOLBOX_BUILD_EXAMPLES=ON
+              -DCMT_CEEDLING_USE_CEXCEPTION=ON
+              -DCMAKE_C_COMPILER=clang
+              -DCMAKE_CXX_COMPILER=clang++
+            install_deps: |
+              sudo apt-get update
+              sudo apt-get install -y clang clang-format gcovr
+
           # ── macOS ────────────────────────────────────────────────────────
           - name: macos-baseline
             os: macos-latest

--- a/cmake/Ceedling.cmake
+++ b/cmake/Ceedling.cmake
@@ -43,6 +43,21 @@ Cache Variables
   Default labels applied to Ceedling tests.
   Default: unit
 
+``CMT_CEEDLING_USE_CEXCEPTION``
+  Enable CException integration. When ON, CException is automatically fetched
+  (via FetchContent) if not found, and linked to every ``Ceedling_AddUnitTest``
+  target. Enables ``Throw()``/``Try``/``Catch`` in both production code and
+  unit tests.
+  Default: OFF
+
+``CMT_CEXCEPTION_GIT_REPOSITORY``
+  CException repository URL used when fetching via FetchContent.
+  Default: ``https://github.com/ThrowTheSwitch/CException.git``
+
+``CMT_CEXCEPTION_GIT_TAG``
+  CException git tag used when fetching via FetchContent.
+  Default: ``v1.3.3``
+
 Functions
 ^^^^^^^^^
 
@@ -114,6 +129,17 @@ option(CMT_CEEDLING_ENABLE_SANITIZER "Enable sanitizer" OFF)
 option(CMT_CEEDLING_SANITIZER_DEFAULT "Enable sanitizer by default" ON)
 option(CMT_CEEDLING_EXTRACT_FUNCTIONS "Extract test functions as separate ctest test" OFF)
 set(CMT_CEEDLING_TEST_LABELS "unit" CACHE STRING "Default labels for Ceedling tests")
+option(CMT_CEEDLING_USE_CEXCEPTION "Enable CException integration for unit tests" OFF)
+set(CMT_CEXCEPTION_GIT_REPOSITORY
+    "https://github.com/ThrowTheSwitch/CException.git"
+    CACHE STRING
+    "CException repository URL (used when fetching via FetchContent)"
+)
+set(CMT_CEXCEPTION_GIT_TAG
+    "v1.3.3"
+    CACHE STRING
+    "CException version tag (used when fetching via FetchContent)"
+)
 
 set(_ceedling_gcovr_post_run_default OFF)
 if(CMT_CEEDLING_ENABLE_GCOV)
@@ -153,6 +179,23 @@ if(CMT_CEEDLING_EXTRACT_FUNCTIONS AND TARGET Unity::Unity)
     else()
         target_compile_definitions(Unity::Unity PUBLIC UNITY_USE_COMMAND_LINE_ARGS)
     endif()
+endif()
+
+if(CMT_CEEDLING_USE_CEXCEPTION)
+    if(NOT TARGET CException::CException)
+        set(CEXCEPTION_FETCH ON)
+        find_package(CException REQUIRED)
+        if(NOT TARGET CException::CException)
+            message(
+                FATAL_ERROR
+                "Ceedling: CMT_CEEDLING_USE_CEXCEPTION=ON but find_package(CException) did not "
+                "provide the CException::CException imported target. Ensure your CException "
+                "installation exports this target, or unset CException_DIR to let cmake_toolbox "
+                "fetch CException automatically via FetchContent."
+            )
+        endif()
+    endif()
+    message(STATUS "Ceedling: CException integration enabled")
 endif()
 
 # ==============================================================================
@@ -442,6 +485,9 @@ function(Ceedling_AddUnitTest)
             Unity::CMock
             Unity::Unity
     )
+    if(CMT_CEEDLING_USE_CEXCEPTION AND TARGET CException::CException)
+        target_link_libraries(${ARG_NAME} PRIVATE CException::CException)
+    endif()
 
     # Setup build directory
     set(TEST_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/${ARG_NAME}.dir")
@@ -583,14 +629,24 @@ function(Ceedling_AddUnitTest)
     if(_cmt_ceedling_test_labels)
         list(REMOVE_DUPLICATES _cmt_ceedling_test_labels)
         set(_cmt_ceedling_test_labels_string "${_cmt_ceedling_test_labels}")
-        string(REPLACE ";" "\\;" _cmt_ceedling_test_labels_escaped "${_cmt_ceedling_test_labels_string}")
+        string(
+            REPLACE
+            ";"
+            "\\;"
+            _cmt_ceedling_test_labels_escaped
+            "${_cmt_ceedling_test_labels_string}"
+        )
     endif()
 
     set(_cmt_ceedling_gcovr_fixture_required "")
     if(CMT_CEEDLING_ENABLE_GCOV AND CMT_CEEDLING_GCOVR_POST_RUN AND TARGET gcovr)
         set(_cmt_ceedling_gcovr_fixture_required "gcovr_unit")
 
-        get_property(_cmt_ceedling_gcovr_post_run_added GLOBAL PROPERTY CMT_CEEDLING_GCOVR_POST_RUN_ADDED)
+        get_property(
+            _cmt_ceedling_gcovr_post_run_added
+            GLOBAL
+            PROPERTY CMT_CEEDLING_GCOVR_POST_RUN_ADDED
+        )
         if(NOT _cmt_ceedling_gcovr_post_run_added)
             set(_cmt_ceedling_gcovr_build_cmd
                 ${CMAKE_COMMAND}
@@ -689,9 +745,11 @@ function(Ceedling_AddUnitTest)
             COMMAND
                 "${CMAKE_COMMAND}" -D "TEST_EXECUTABLE=$<TARGET_FILE:${ARG_NAME}>" -D
                 "TEST_WORKING_DIR=${CMAKE_CURRENT_BINARY_DIR}" -D
-                "TEST_SUITE=$<TARGET_FILE_NAME:${ARG_NAME}>" -D "TEST_FILE=${CMT_CEEDLING_UNITY_TEST_FILE}" -D
-                "TEST_ENVIRONMENT=${_cmt_ceedling_sanitizer_test_environment}" ${_cmt_ceedling_test_labels_arg}
-                ${_cmt_ceedling_test_fixtures_arg} -P "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/DiscoverTests.cmake"
+                "TEST_SUITE=$<TARGET_FILE_NAME:${ARG_NAME}>" -D
+                "TEST_FILE=${CMT_CEEDLING_UNITY_TEST_FILE}" -D
+                "TEST_ENVIRONMENT=${_cmt_ceedling_sanitizer_test_environment}"
+                ${_cmt_ceedling_test_labels_arg} ${_cmt_ceedling_test_fixtures_arg} -P
+                "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/DiscoverTests.cmake"
             VERBATIM
         )
 

--- a/cmake/FindCException.cmake
+++ b/cmake/FindCException.cmake
@@ -1,0 +1,218 @@
+# SPDX-License-Identifier: MIT
+# ============================================================================
+# FindCException
+# ============================================================================
+#
+# CMake find module for the CException C exception-handling library.
+#
+# This module locates existing CException source distributions and provides
+# an imported target for convenient linking. Can also fetch via FetchContent.
+#
+# Usage:
+#   find_package(CException REQUIRED)   # Basic usage
+#   find_package(CException QUIET)      # Suppress status output
+#
+# User Cache / Environment Hints:
+#   - CException_ROOT / CEXCEPTION_ROOT (cache or normal variable)
+#   - ENV{CEXCEPTION_ROOT}
+#   - CEXCEPTION_FETCH (BOOL, OFF by default)  If ON and CException not found,
+#       the repository will be fetched via FetchContent.
+#   - CMT_CEXCEPTION_GIT_REPOSITORY (override CException repo URL)
+#   - CMT_CEXCEPTION_GIT_TAG (override CException tag)
+#
+# Result Variables:
+#   CException_FOUND        - TRUE if CException located (or fetched)
+#   CException_INCLUDE_DIR  - Directory containing CException.h
+#   CException_SOURCE       - Path to CException.c (required)
+#   CException_VERSION      - Parsed version string if detected
+#
+# Imported Targets:
+#   CException::CException  - Static library target (compiles CException.c)
+#
+# Notes:
+#   - Both CException.h AND CException.c are required (no header-only mode)
+#   - CExceptionConfig.h lives in the same directory as CException.h and is
+#     automatically available through the target's include directories
+#
+# ============================================================================
+
+include_guard(GLOBAL)
+
+# ----------------------------------------------------------------------------
+# Handle user overrides / hints
+# ----------------------------------------------------------------------------
+set(_CException_HINT_DIRS)
+foreach(var IN ITEMS CException_ROOT CEXCEPTION_ROOT)
+    if(DEFINED ${var})
+        list(APPEND _CException_HINT_DIRS "${${var}}")
+    endif()
+endforeach()
+if(DEFINED ENV{CEXCEPTION_ROOT})
+    list(APPEND _CException_HINT_DIRS "$ENV{CEXCEPTION_ROOT}")
+endif()
+
+# Common relative subdirs to search inside each hint root
+set(_CException_SUBDIRS
+    ""
+    "src"
+    "lib"
+    "source"
+    "CException"
+    "CException/src"
+    "CException/lib"
+)
+
+# ----------------------------------------------------------------------------
+# Locate CException.h
+# ----------------------------------------------------------------------------
+unset(CException_INCLUDE_DIR CACHE)
+find_path(
+    CException_INCLUDE_DIR
+    NAMES
+        CException.h
+    HINTS
+        ${_CException_HINT_DIRS}
+    PATH_SUFFIXES
+        ${_CException_SUBDIRS}
+)
+
+# ----------------------------------------------------------------------------
+# Locate CException.c (required)
+# ----------------------------------------------------------------------------
+unset(CException_SOURCE CACHE)
+find_file(
+    CException_SOURCE
+    NAMES
+        CException.c
+    HINTS
+        ${CException_INCLUDE_DIR}
+        ${_CException_HINT_DIRS}
+    PATH_SUFFIXES
+        .
+        src
+        lib
+        source
+        CException
+        CException/src
+        CException/lib
+)
+
+# ----------------------------------------------------------------------------
+# Optional: Fetch if not found and user requested CEXCEPTION_FETCH
+# ----------------------------------------------------------------------------
+if((NOT CException_INCLUDE_DIR OR NOT CException_SOURCE) AND CEXCEPTION_FETCH)
+    set(_cexception_repo "https://github.com/ThrowTheSwitch/CException.git")
+    if(CMT_CEXCEPTION_GIT_REPOSITORY)
+        set(_cexception_repo "${CMT_CEXCEPTION_GIT_REPOSITORY}")
+    endif()
+    set(_cexception_tag "v1.3.3")
+    if(CMT_CEXCEPTION_GIT_TAG)
+        set(_cexception_tag "${CMT_CEXCEPTION_GIT_TAG}")
+    endif()
+
+    include(FetchContent)
+
+    FetchContent_Declare(
+        cexception_repo
+        GIT_REPOSITORY "${_cexception_repo}"
+        GIT_TAG "${_cexception_tag}"
+    )
+    FetchContent_MakeAvailable(cexception_repo)
+
+    if(cexception_repo_SOURCE_DIR AND EXISTS "${cexception_repo_SOURCE_DIR}/lib/CException.c")
+        set(CException_INCLUDE_DIR "${cexception_repo_SOURCE_DIR}/lib")
+        set(CException_SOURCE "${cexception_repo_SOURCE_DIR}/lib/CException.c")
+    endif()
+endif()
+
+# ----------------------------------------------------------------------------
+# Parse version from CException.h macros (cross-compile safe)
+# ----------------------------------------------------------------------------
+unset(CException_VERSION)
+if(CException_INCLUDE_DIR AND EXISTS "${CException_INCLUDE_DIR}/CException.h")
+    set(_cexception_header "${CException_INCLUDE_DIR}/CException.h")
+    file(
+        STRINGS "${_cexception_header}"
+        _cexception_version_lines
+        REGEX "^#[ \t]*define[ \t]+CEXCEPTION_VERSION_(MAJOR|MINOR|BUILD)[ \t]+[0-9]+"
+    )
+
+    unset(_cexception_major)
+    unset(_cexception_minor)
+    unset(_cexception_patch)
+    foreach(_cexception_line IN LISTS _cexception_version_lines)
+        if(_cexception_line MATCHES "^#[ \t]*define[ \t]+CEXCEPTION_VERSION_MAJOR[ \t]+([0-9]+)")
+            set(_cexception_major "${CMAKE_MATCH_1}")
+        elseif(
+            _cexception_line
+                MATCHES
+                "^#[ \t]*define[ \t]+CEXCEPTION_VERSION_MINOR[ \t]+([0-9]+)"
+        )
+            set(_cexception_minor "${CMAKE_MATCH_1}")
+        elseif(
+            _cexception_line
+                MATCHES
+                "^#[ \t]*define[ \t]+CEXCEPTION_VERSION_BUILD[ \t]+([0-9]+)"
+        )
+            set(_cexception_patch "${CMAKE_MATCH_1}")
+        endif()
+    endforeach()
+
+    if(DEFINED _cexception_major AND DEFINED _cexception_minor)
+        set(CException_VERSION "${_cexception_major}.${_cexception_minor}")
+        if(DEFINED _cexception_patch)
+            string(APPEND CException_VERSION ".${_cexception_patch}")
+        endif()
+    endif()
+
+    unset(_cexception_header)
+    unset(_cexception_version_lines)
+    unset(_cexception_line)
+    unset(_cexception_major)
+    unset(_cexception_minor)
+    unset(_cexception_patch)
+endif()
+
+# ----------------------------------------------------------------------------
+# Create imported target
+# ----------------------------------------------------------------------------
+if(CException_INCLUDE_DIR AND CException_SOURCE)
+    if(NOT TARGET CException::CException)
+        add_library(cexception_cexception STATIC "${CException_SOURCE}")
+        target_include_directories(cexception_cexception PUBLIC "${CException_INCLUDE_DIR}")
+        # Disable linting for external dependencies
+        set_target_properties(
+            cexception_cexception
+            PROPERTIES
+                C_CLANG_TIDY
+                    ""
+                SKIP_LINTING
+                    TRUE
+        )
+        # Create namespaced alias
+        add_library(CException::CException ALIAS cexception_cexception)
+    endif()
+endif()
+
+# ----------------------------------------------------------------------------
+# Set required standard find_package variables
+# ----------------------------------------------------------------------------
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(
+    CException
+    REQUIRED_VARS
+        CException_INCLUDE_DIR
+        CException_SOURCE
+    VERSION_VAR CException_VERSION
+)
+
+mark_as_advanced(
+    CException_INCLUDE_DIR
+    CException_SOURCE
+)
+
+if(CException_FOUND AND NOT CException_FIND_QUIETLY)
+    message(STATUS "FindCException: Found CException ${CException_VERSION}")
+    message(STATUS "FindCException:   Include: ${CException_INCLUDE_DIR}")
+    message(STATUS "FindCException:   Source:  ${CException_SOURCE}")
+endif()

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -16,6 +16,20 @@ Ceedling_AddUnitTest(
     ENABLE_SANITIZER
 )
 
+if(CMT_CEEDLING_USE_CEXCEPTION)
+    add_library(example_cexception STATIC ${CMAKE_CURRENT_SOURCE_DIR}/source/example_cexception.c)
+    target_include_directories(example_cexception PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
+    target_link_libraries(example_cexception PUBLIC CException::CException)
+
+    Ceedling_AddUnitTest(
+        NAME example_cexception_test
+        UNIT_TEST ${CMAKE_CURRENT_SOURCE_DIR}/unit_test/test_example_cexception.c
+        TARGET example_cexception
+        LABELS
+            cexception
+    )
+endif()
+
 # Automatically add all policy unit tests to CTest
 file(GLOB POLICY_TEST_FILES "${CMAKE_CURRENT_LIST_DIR}/../unit_tests/policy/test_*.cmake")
 foreach(test_file ${POLICY_TEST_FILES})
@@ -76,6 +90,27 @@ foreach(test_file ${FINDUNITY_TEST_FILES})
         PROPERTIES
             LABELS
                 "script;findunity"
+    )
+endforeach()
+
+# Automatically add all FindCException unit tests to CTest
+file(
+    GLOB FINDCEXCEPTION_TEST_FILES
+    "${CMAKE_CURRENT_LIST_DIR}/../unit_tests/findcexception/test_*.cmake"
+)
+foreach(test_file ${FINDCEXCEPTION_TEST_FILES})
+    get_filename_component(test_filename ${test_file} NAME_WE)
+    string(REGEX REPLACE "^test_" "" test_name ${test_filename})
+    add_test(
+        NAME findcexception_${test_name}
+        COMMAND
+            ${CMAKE_COMMAND} -P ${test_file}
+    )
+    set_tests_properties(
+        findcexception_${test_name}
+        PROPERTIES
+            LABELS
+                "script;findcexception"
     )
 endforeach()
 
@@ -667,3 +702,31 @@ foreach(test_file ${UNITY_INTEGRATION_TESTS})
                 "integration;unity"
     )
 endforeach()
+
+# CException Integration Tests
+if(CMT_CEEDLING_USE_CEXCEPTION)
+    file(
+        GLOB CEXCEPTION_INTEGRATION_TESTS
+        "${CMAKE_CURRENT_LIST_DIR}/../unit_tests/integration/cexception/test_*.cmake"
+    )
+    foreach(test_file ${CEXCEPTION_INTEGRATION_TESTS})
+        get_filename_component(test_filename ${test_file} NAME_WE)
+        string(REGEX REPLACE "^test_" "" test_name ${test_filename})
+        add_test(
+            NAME integration_cexception_${test_name}
+            COMMAND
+                ${CMAKE_COMMAND} -DCMAKE_TOOLBOX_TEST_GENERATOR=${CMAKE_GENERATOR}
+                -DCMAKE_TOOLBOX_TEST_C_COMPILER=${CMAKE_C_COMPILER}
+                -DCMAKE_TOOLBOX_TEST_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+                -DCMAKE_TOOLBOX_TEST_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+                -DCMAKE_TOOLBOX_TEST_ARTIFACTS_ROOT=${CMAKE_CURRENT_BINARY_DIR}/test_artifacts -P
+                ${test_file}
+        )
+        set_tests_properties(
+            integration_cexception_${test_name}
+            PROPERTIES
+                LABELS
+                    "integration;cexception"
+        )
+    endforeach()
+endif()

--- a/examples/include/example_cexception.h
+++ b/examples/include/example_cexception.h
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+#ifndef EXAMPLE_CEXCEPTION_H
+#define EXAMPLE_CEXCEPTION_H
+
+#include "CException.h"
+
+#define ERROR_DIVISION_BY_ZERO ((CEXCEPTION_T)1)
+
+void example_divide(int a, int b, int *result);
+
+#endif /* EXAMPLE_CEXCEPTION_H */

--- a/examples/source/example_cexception.c
+++ b/examples/source/example_cexception.c
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+#include "example_cexception.h"
+
+void example_divide(int a, int b, int *result)
+{
+    if (b == 0)
+    {
+        Throw(ERROR_DIVISION_BY_ZERO);
+    }
+    *result = a / b;
+}

--- a/examples/unit_test/test_example_cexception.c
+++ b/examples/unit_test/test_example_cexception.c
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT
+#include "unity.h"
+#include "CException.h"
+#include "example_cexception.h"
+
+void setUp(void)
+{
+}
+
+void tearDown(void)
+{
+}
+
+void test_divide_success(void)
+{
+    int result = 0;
+    example_divide(10, 2, &result);
+    TEST_ASSERT_EQUAL_INT(5, result);
+}
+
+void test_divide_by_zero_throws(void)
+{
+    CEXCEPTION_T e = CEXCEPTION_NONE;
+    int result     = 0;
+    Try
+    {
+        example_divide(10, 0, &result);
+        TEST_FAIL_MESSAGE("Expected exception was not thrown");
+    }
+    Catch(e)
+    {
+        TEST_ASSERT_EQUAL_INT((int)ERROR_DIVISION_BY_ZERO, (int)e);
+    }
+}

--- a/unit_tests/findcexception/README.md
+++ b/unit_tests/findcexception/README.md
@@ -1,0 +1,21 @@
+# FindCException Module Unit Tests
+
+Tests for the `FindCException` CMake find module.
+
+## Test Files
+
+- `test_find_cexception.cmake` — Verifies `find_package(CException QUIET)` completes without
+  error regardless of whether CException is installed. If found, validates that result variables
+  (`CException_INCLUDE_DIR`, `CException_SOURCE`) are set.
+
+## Running
+
+```sh
+cmake -P unit_tests/findcexception/test_find_cexception.cmake
+```
+
+Or via CTest after configuring the examples directory:
+
+```sh
+ctest -L findcexception
+```

--- a/unit_tests/findcexception/test_find_cexception.cmake
+++ b/unit_tests/findcexception/test_find_cexception.cmake
@@ -1,0 +1,31 @@
+# Test: FindCException module
+# Purpose: Verify that find_package(CException) works correctly
+# Expected: PASS (with or without CException installed)
+# Executable: cmake -P test_find_cexception.cmake
+
+cmake_minimum_required(VERSION 3.22)
+set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/../../cmake")
+
+find_package(CException QUIET MODULE)
+
+if(CException_FOUND)
+    if(NOT CException_INCLUDE_DIR)
+        message(FATAL_ERROR "FAIL: CException_FOUND=TRUE but CException_INCLUDE_DIR is empty")
+    endif()
+    if(NOT CException_SOURCE)
+        message(FATAL_ERROR "FAIL: CException_FOUND=TRUE but CException_SOURCE is empty")
+    endif()
+    if(NOT TARGET CException::CException)
+        message(
+            FATAL_ERROR
+            "FAIL: CException_FOUND=TRUE but CException::CException target was not created"
+        )
+    endif()
+    message(STATUS "PASS: CException found")
+    message(STATUS "  Include: ${CException_INCLUDE_DIR}")
+    message(STATUS "  Source:  ${CException_SOURCE}")
+else()
+    message(STATUS "PASS: CException not found (expected in CI without library installed)")
+endif()
+
+message(STATUS "PASS: FindCException module test completed successfully")

--- a/unit_tests/integration/cexception/test_cexception_integration.cmake
+++ b/unit_tests/integration/cexception/test_cexception_integration.cmake
@@ -1,0 +1,211 @@
+if(NOT DEFINED CMAKE_TOOLBOX_TEST_ARTIFACTS_ROOT)
+    if(DEFINED CMAKE_BINARY_DIR AND NOT CMAKE_BINARY_DIR STREQUAL "")
+        set(CMAKE_TOOLBOX_TEST_ARTIFACTS_ROOT "${CMAKE_BINARY_DIR}/test_artifacts")
+    elseif(DEFINED CMAKE_CURRENT_BINARY_DIR AND NOT CMAKE_CURRENT_BINARY_DIR STREQUAL "")
+        set(CMAKE_TOOLBOX_TEST_ARTIFACTS_ROOT "${CMAKE_CURRENT_BINARY_DIR}/test_artifacts")
+    else()
+        set(CMAKE_TOOLBOX_TEST_ARTIFACTS_ROOT "${CMAKE_CURRENT_LIST_DIR}/test_artifacts")
+    endif()
+endif()
+
+get_filename_component(REPO_ROOT "${CMAKE_CURRENT_LIST_DIR}/../../.." ABSOLUTE)
+set(CMAKE_MODULE_PATH
+    "${REPO_ROOT}/cmake"
+    ${CMAKE_MODULE_PATH}
+)
+include(TestHelpers)
+
+set(ERROR_COUNT 0)
+set_property(
+    GLOBAL
+    PROPERTY
+        CMT_CEXCEPTION_INTEGRATION_ERROR_COUNT
+            0
+)
+set(TEST_ROOT "${CMAKE_TOOLBOX_TEST_ARTIFACTS_ROOT}/integration_cexception")
+
+set(_cmt_test_build_config "")
+if(DEFINED CMAKE_TOOLBOX_TEST_BUILD_TYPE AND NOT CMAKE_TOOLBOX_TEST_BUILD_TYPE STREQUAL "")
+    set(_cmt_test_build_config "${CMAKE_TOOLBOX_TEST_BUILD_TYPE}")
+elseif(
+    DEFINED
+        CMAKE_TOOLBOX_TEST_GENERATOR
+    AND CMAKE_TOOLBOX_TEST_GENERATOR
+        MATCHES
+        "Visual Studio|Xcode|Multi-Config|Ninja Multi-Config"
+)
+    set(_cmt_test_build_config "Debug")
+endif()
+
+if(_cmt_test_build_config)
+    set(CMAKE_TOOLBOX_TEST_BUILD_TYPE "${_cmt_test_build_config}")
+endif()
+
+macro(fail message_text)
+    message(STATUS "  FAIL: ${message_text}")
+    get_property(_cmt_test_error_count GLOBAL PROPERTY CMT_CEXCEPTION_INTEGRATION_ERROR_COUNT)
+    if(NOT _cmt_test_error_count)
+        set(_cmt_test_error_count 0)
+    endif()
+    math(EXPR _cmt_test_error_count "${_cmt_test_error_count} + 1")
+    set_property(
+        GLOBAL
+        PROPERTY
+            CMT_CEXCEPTION_INTEGRATION_ERROR_COUNT
+                ${_cmt_test_error_count}
+    )
+    set(ERROR_COUNT "${_cmt_test_error_count}" PARENT_SCOPE)
+endmacro()
+
+function(write_project src_dir)
+    file(MAKE_DIRECTORY "${src_dir}/src")
+    file(MAKE_DIRECTORY "${src_dir}/include")
+    file(MAKE_DIRECTORY "${src_dir}/test")
+
+    set(test_cmake_lists
+        "cmake_minimum_required(VERSION 3.22)
+project(CExceptionIntegration LANGUAGES C)
+
+list(APPEND CMAKE_MODULE_PATH \"${REPO_ROOT}/cmake\")
+
+# Isolate from any system-installed CException config packages so that
+# FindCException.cmake + FetchContent path is always exercised
+set(CMAKE_FIND_USE_PACKAGE_REGISTRY FALSE)
+set(CMAKE_FIND_USE_SYSTEM_PACKAGE_REGISTRY FALSE)
+set(CMAKE_FIND_PACKAGE_PREFER_CONFIG FALSE)
+set(CMAKE_PREFIX_PATH \"\")
+
+enable_testing()
+
+include(Ceedling)
+
+add_library(mylib STATIC src/mylib.c)
+target_include_directories(mylib PUBLIC \"\${CMAKE_CURRENT_SOURCE_DIR}/include\")
+target_link_libraries(mylib PRIVATE CException::CException)
+
+Ceedling_AddUnitTest(
+    NAME mylib_test
+    UNIT_TEST \"\${CMAKE_CURRENT_SOURCE_DIR}/test/test_mylib.c\"
+    TARGET mylib
+)
+"
+    )
+
+    set(mylib_header
+        "#ifndef MYLIB_H\n#define MYLIB_H\n#define ERR_BAD_ARG 1\nvoid mylib_divide(int a, int b, int *result);\nint mylib_value(void);\n#endif\n"
+    )
+
+    set(mylib_source
+        "#include \"mylib.h\"\n#include \"CException.h\"\nvoid mylib_divide(int a, int b, int *result) {\n    if (b == 0) Throw(ERR_BAD_ARG);\n    *result = a / b;\n}\nint mylib_value(void) { return 42; }\n"
+    )
+
+    set(test_source
+        "#include \"unity.h\"\n#include \"CException.h\"\n#include \"mylib.h\"\nvoid setUp(void) {}\nvoid tearDown(void) {}\nvoid test_value(void) {\n    TEST_ASSERT_EQUAL_INT(42, mylib_value());\n}\nvoid test_divide_ok(void) {\n    int result = 0;\n    mylib_divide(10, 2, &result);\n    TEST_ASSERT_EQUAL_INT(5, result);\n}\nvoid test_divide_throws(void) {\n    CEXCEPTION_T e = CEXCEPTION_NONE;\n    int result = 0;\n    Try {\n        mylib_divide(10, 0, &result);\n        TEST_FAIL_MESSAGE(\"Expected exception not thrown\");\n    } Catch(e) {\n        TEST_ASSERT_EQUAL_INT(ERR_BAD_ARG, (int)e);\n    }\n}\n"
+    )
+
+    file(WRITE "${src_dir}/CMakeLists.txt" "${test_cmake_lists}")
+    file(WRITE "${src_dir}/include/mylib.h" "${mylib_header}")
+    file(WRITE "${src_dir}/src/mylib.c" "${mylib_source}")
+    file(WRITE "${src_dir}/test/test_mylib.c" "${test_source}")
+endfunction()
+
+function(configure_project src_dir build_dir)
+    TestHelpers_GetConfigureArgs(configure_args)
+    execute_process(
+        COMMAND
+            ${CMAKE_COMMAND} -S "${src_dir}" -B "${build_dir}" ${configure_args}
+            -DCMT_CEEDLING_USE_CEXCEPTION=ON
+        RESULT_VARIABLE result
+        OUTPUT_VARIABLE output
+        ERROR_VARIABLE error
+    )
+    if(NOT result EQUAL 0)
+        fail("Configure failed:\n${output}\n${error}")
+    else()
+        message(STATUS "  [PASS] Configure succeeded")
+    endif()
+endfunction()
+
+function(build_project build_dir)
+    set(build_args "")
+    if(DEFINED CMAKE_TOOLBOX_TEST_BUILD_TYPE AND NOT CMAKE_TOOLBOX_TEST_BUILD_TYPE STREQUAL "")
+        list(
+            APPEND build_args
+            --config
+            "${CMAKE_TOOLBOX_TEST_BUILD_TYPE}"
+        )
+    endif()
+
+    execute_process(
+        COMMAND
+            ${CMAKE_COMMAND} --build "${build_dir}" ${build_args}
+        RESULT_VARIABLE result
+        OUTPUT_VARIABLE output
+        ERROR_VARIABLE error
+    )
+    if(NOT result EQUAL 0)
+        fail("Build failed:\n${output}\n${error}")
+    else()
+        message(STATUS "  [PASS] Build succeeded")
+    endif()
+endfunction()
+
+function(run_tests build_dir)
+    set(ctest_args "")
+    if(DEFINED CMAKE_TOOLBOX_TEST_BUILD_TYPE AND NOT CMAKE_TOOLBOX_TEST_BUILD_TYPE STREQUAL "")
+        list(
+            APPEND ctest_args
+            -C
+            "${CMAKE_TOOLBOX_TEST_BUILD_TYPE}"
+        )
+    endif()
+
+    if(NOT CMAKE_CTEST_COMMAND)
+        set(CMAKE_CTEST_COMMAND ctest)
+    endif()
+    execute_process(
+        COMMAND
+            ${CMAKE_CTEST_COMMAND} --test-dir "${build_dir}" ${ctest_args} --output-on-failure
+        RESULT_VARIABLE result
+        OUTPUT_VARIABLE output
+        ERROR_VARIABLE error
+    )
+    if(NOT result EQUAL 0)
+        fail("Tests failed: ${output}\n${error}")
+    else()
+        message(STATUS "  [PASS] All tests passed")
+    endif()
+endfunction()
+
+# ── main ────────────────────────────────────────────────────────────────────
+
+message(STATUS "=== CException integration test ===")
+file(REMOVE_RECURSE "${TEST_ROOT}")
+file(MAKE_DIRECTORY "${TEST_ROOT}")
+
+set(SRC_DIR "${TEST_ROOT}/src")
+set(BUILD_DIR "${TEST_ROOT}/build")
+
+write_project("${SRC_DIR}")
+
+get_property(ERROR_COUNT GLOBAL PROPERTY CMT_CEXCEPTION_INTEGRATION_ERROR_COUNT)
+if(ERROR_COUNT EQUAL 0)
+    configure_project("${SRC_DIR}" "${BUILD_DIR}")
+endif()
+
+get_property(ERROR_COUNT GLOBAL PROPERTY CMT_CEXCEPTION_INTEGRATION_ERROR_COUNT)
+if(ERROR_COUNT EQUAL 0)
+    build_project("${BUILD_DIR}")
+endif()
+
+get_property(ERROR_COUNT GLOBAL PROPERTY CMT_CEXCEPTION_INTEGRATION_ERROR_COUNT)
+if(ERROR_COUNT EQUAL 0)
+    run_tests("${BUILD_DIR}")
+endif()
+
+get_property(ERROR_COUNT GLOBAL PROPERTY CMT_CEXCEPTION_INTEGRATION_ERROR_COUNT)
+if(ERROR_COUNT GREATER 0)
+    message(FATAL_ERROR "CException integration tests FAILED (${ERROR_COUNT} error(s))")
+else()
+    message(STATUS "CException integration tests PASSED")
+endif()


### PR DESCRIPTION
Closes #33

## Summary

Adds optional CException integration to the Ceedling module, following the same FetchContent pattern established by Unity/CMock.

## Changes

### New files
- **`cmake/FindCException.cmake`** — find module with FetchContent fallback; version parsing from macros; creates `CException::CException` ALIAS target following `FindUnity.cmake` conventions
- **`examples/include/example_cexception.h`** — example public API exposing error codes
- **`examples/source/example_cexception.c`** — production code using `Throw()` on error
- **`examples/unit_test/test_example_cexception.c`** — Unity tests using `Try/Catch` to verify exception behaviour
- **`unit_tests/findcexception/test_find_cexception.cmake`** — advisory script test for `find_package(CException QUIET)`
- **`unit_tests/findcexception/README.md`**
- **`unit_tests/integration/cexception/test_cexception_integration.cmake`** — end-to-end integration test: writes a real CMake project, configures, builds, and runs CTest with 3 Unity+CException tests

### Modified files
- **`cmake/Ceedling.cmake`** — RST docstring updated; `CMT_CEEDLING_USE_CEXCEPTION` option added (default `OFF`); auto-fetch/resolve block after `Unity_Initialize()`; auto-link `CException::CException` in `Ceedling_AddUnitTest()`
- **`examples/CMakeLists.txt`** — CException example target + unit test; `findcexception` script test registration; integration test registration
- **`.github/workflows/ci.yml`** — two new matrix entries: `linux-cexception` (GCC) and `linux-clang-cexception` (Clang)

## Usage

```cmake
cmake -S . -B build -DCMT_CEEDLING_USE_CEXCEPTION=ON
```

CException is fetched automatically from GitHub via FetchContent if not found locally. When `OFF` (the default), behaviour is identical to before — zero cost.

## Acceptance criteria

- [x] CException can be enabled with a single variable (`CMT_CEEDLING_USE_CEXCEPTION=ON`)
- [x] Test targets link CException automatically — no user boilerplate
- [x] Clear `FATAL_ERROR` when enabled but not resolvable (`find_package(CException REQUIRED)`)
- [x] No behaviour changes when the option is off

## Test results

All 85 CTest tests pass, including:
- `findcexception_find_cexception` (script)
- `unit_example_cexception_test` (Ceedling unit test with `Try/Catch`)
- `integration_cexception_cexception_integration` (end-to-end)
